### PR TITLE
Fixed you readme to passthru password correct to pia-setup-tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Wireguard keys, and forwarded ipv4 port, it requires some tooling to set up.
    wireguard private keys. These files do not store your [PIA][] username or
    password, but should still be treated as private.
 
-3. Run `pia-setup-tunnel -username <user> -password <pass> -ifname <interface>`
+3. Run `pia-setup-tunnel --username <user> --password <pass> --ifname <interface>`
    as root to create the `.network` and `.netdev` files corresponding to the
    templates created above.
 


### PR DESCRIPTION
Hi

I spent a lot of type trying to find out why the script didn't work but found out now that you had written
pia-setup-tunnel -username <user> -password <pass> -ifname <interface>

But it should be 

pia-setup-tunnel --username <user> --password <pass> --ifname <interface>
