### PR TITLE
fix: use PIA client API for token generation

### DIFF
--- a/internal/pia/token.go
+++ b/internal/pia/token.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -17,28 +19,38 @@ func (t Token) Valid() bool {
 }
 
 func (tun *Tunnel) NewToken(username string, password string) error {
-	url := fmt.Sprintf("https://%s/authv3/generateToken", tun.Region.MetaServer().Ip)
-	req, err := http.NewRequest("GET", url, nil)
+	vals := url.Values{
+		"username": {username},
+		"password": {password},
+	}
+	req, err := http.NewRequest("POST", "https://www.privateinternetaccess.com/api/client/v2/token", strings.NewReader(vals.Encode()))
 	if err != nil {
 		return err
 	}
-	req.SetBasicAuth(username, password)
-	resp, err := doRequest(req, tun.Region.MetaServer().Cn)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
-	var vals map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&vals); err != nil {
+	var tokenResp struct {
+		Token   string `json:"token"`
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
 		return err
 	}
-	if vals["status"] != "OK" {
-		return fmt.Errorf("Error generating PIA token: status=\"%s\" message=\"%s\"", vals["status"], vals["message"])
+	if tokenResp.Token == "" {
+		if tokenResp.Status != "" || tokenResp.Message != "" {
+			return fmt.Errorf("Error generating PIA token: status=\"%s\" message=\"%s\"", tokenResp.Status, tokenResp.Message)
+		}
+		return fmt.Errorf("Error generating PIA token: empty token response (HTTP %s)", resp.Status)
 	}
 	day, _ := time.ParseDuration("23h55m")
 	tun.Token = Token{
-		Token:  vals["token"],
+		Token:  tokenResp.Token,
 		Expiry: time.Now().Add(day),
 	}
 	return nil


### PR DESCRIPTION
PIA has changed its token generation flow, and the regional authv3/generateToken endpoint is no longer the correct integration point for this client.

While investigating the failure, we checked PIA's current [manual-connections](https://github.com/pia-foss/manual-connections) tooling and found that it now requests tokens from https://www.privateinternetaccess.com/api/client/v2/token instead.

This change updates pia-tools to follow that current token API and leaves the existing WireGuard server request flow unchanged.